### PR TITLE
Revise setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# 初期セットアップ
+setup:
+	docker-compose build
+	docker-compose up
+
+# dockerの状態をすべてclean up してコンテナを立て直す(時間がかかるが、なにかおかしいときに使える)
+reset:
+	docker-compose down --rmi all --volumes --remove-orphans
+	docker-compose build --no-cache
+	docker-compose up
+
+# docker内のnode-modulesを最新にし、yarn buildし直す
+yarn-build-docker:
+	docker-compose exec frontend bash -c "yarn install --no-save"
+	docker-compose exec frontend bash -c "yarn build"

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,6 @@ reset:
 
 # docker内のnode-modulesを最新にし、yarn buildし直す
 yarn-build-docker:
+	docker-compose up -d
 	docker-compose exec frontend bash -c "yarn install --no-save"
 	docker-compose exec frontend bash -c "yarn build"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,11 @@ services:
   frontend:
     build: ./frontend
     container_name: frontend
+    tty: true
     volumes:
+      - ./frontend:/app
       - front-build:/app/build
+      - front-node-modules:/app/node_modules
   nginx:
     container_name: proxy
     restart: always
@@ -33,6 +36,8 @@ networks:
     driver: bridge
 volumes:
   front-build:
+    driver: local
+  front-node-modules:
     driver: local
   back-node-modules:
     driver: local

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost
+REACT_APP_API_URL=http://localhost:80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,5 +3,5 @@ FROM node:16.12-buster
 WORKDIR /app
 
 COPY ./ ./
-RUN yarn install
-RUN yarn build
+RUN yarn install  --no-save
+RUN yarn build:prod


### PR DESCRIPTION
# what
frontendを構築するとき、毎回 docker-compose build --no-cacheをしていたが、簡単にするためMakefileを作成
またフロントのnode-modulesをvolumeに保存することで簡単にbuildできるようにした